### PR TITLE
Fix Flaky testIndentComplicatedJsonObjectWithArrayAndWithConfig by Sorting Nested JSON Keys

### DIFF
--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -20,6 +20,7 @@ import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.Map;
 
 import org.json.*;
@@ -1249,8 +1250,8 @@ public class XMLTest {
     public void testIndentComplicatedJsonObjectWithArrayAndWithConfig(){
         try (InputStream jsonStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.json")) {
             final JSONObject object = new JSONObject(new JSONTokener(jsonStream));
-            TreeMap<String, Object> sortedMap = new TreeMap<>(object.ToMap());
-            JSONObject object = new JSONObject(sortedMap);
+            TreeMap<String, Object> sortedMap = new TreeMap<>(object.toMap());
+            object = new JSONObject(sortedMap);
             String actualString = XML.toString(object, null, XMLParserConfiguration.KEEP_STRINGS, 2);
             try (InputStream xmlStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.xml")) {
                 int bufferSize = 1024;

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1249,6 +1249,8 @@ public class XMLTest {
     public void testIndentComplicatedJsonObjectWithArrayAndWithConfig(){
         try (InputStream jsonStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.json")) {
             final JSONObject object = new JSONObject(new JSONTokener(jsonStream));
+            TreeMap<String, Object> sortedMap = new TreeMap<>(object.ToMap());
+            JSONObject object = new JSONObject(sortedMap);
             String actualString = XML.toString(object, null, XMLParserConfiguration.KEEP_STRINGS, 2);
             try (InputStream xmlStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.xml")) {
                 int bufferSize = 1024;

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1249,7 +1249,7 @@ public class XMLTest {
     @Test
     public void testIndentComplicatedJsonObjectWithArrayAndWithConfig(){
         try (InputStream jsonStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.json")) {
-            final JSONObject object = new JSONObject(new JSONTokener(jsonStream));
+            JSONObject object = new JSONObject(new JSONTokener(jsonStream));
             TreeMap<String, Object> sortedMap = new TreeMap<>(object.toMap());
             object = new JSONObject(sortedMap);
             String actualString = XML.toString(object, null, XMLParserConfiguration.KEEP_STRINGS, 2);

--- a/src/test/java/org/json/junit/XMLTest.java
+++ b/src/test/java/org/json/junit/XMLTest.java
@@ -1250,8 +1250,7 @@ public class XMLTest {
     public void testIndentComplicatedJsonObjectWithArrayAndWithConfig(){
         try (InputStream jsonStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.json")) {
             JSONObject object = new JSONObject(new JSONTokener(jsonStream));
-            TreeMap<String, Object> sortedMap = new TreeMap<>(object.toMap());
-            object = new JSONObject(sortedMap);
+            object = (JSONObject) deepSort(object);
             String actualString = XML.toString(object, null, XMLParserConfiguration.KEEP_STRINGS, 2);
             try (InputStream xmlStream = XMLTest.class.getClassLoader().getResourceAsStream("Issue593.xml")) {
                 int bufferSize = 1024;
@@ -1265,6 +1264,26 @@ public class XMLTest {
             }
         } catch (IOException e) {
             fail("file writer error: " +e.getMessage());
+        }
+    }
+
+    private static Object deepSort(Object input) {
+        if (input instanceof JSONObject) {
+            JSONObject obj = (JSONObject) input;
+            TreeMap<String, Object> sorted = new TreeMap<>();
+            for (String key : obj.keySet()) {
+                sorted.put(key, deepSort(obj.get(key)));
+            }
+            return new JSONObject(sorted);
+        } else if (input instanceof JSONArray) {
+            JSONArray array = (JSONArray) input;
+            JSONArray sortedArray = new JSONArray();
+            for (int i = 0; i < array.length(); i++) {
+                sortedArray.put(deepSort(array.get(i)));
+            }
+            return sortedArray;
+        } else {
+            return input;
         }
     }
 


### PR DESCRIPTION
### ▸ What is the Purpose of This PR
This PR fixes the flakiness of the test `org.json.junit.XMLTest#testIndentComplicatedJsonObjectWithArrayAndWithConfig`, which failed intermittently due to non-deterministic key ordering in nested JSON objects. This issue caused test assertions to fail when the JSON-to-XML conversion `XML.toString()` method produced different key orderings between runs.


### ▸ Why the Test Fails
The test reads a JSON file `Issue593.json` and compares the resulting XML serialization (converted back to JSON) against an expected XML string `Issue593.xml`. However, `JSONObject` in Java uses `HashMap` internally, which does not guarantee key ordering. This is heightened with the added complexity of deeply nested JSON structures or objects within arrays.


### ▸ How to Reproduce the Test Failure
Run the test repeatedly or with the [NonDex](https://github.com/TestingResearchIllinois/NonDex) plugin, which systematically explores different field ordering and iteration orderings in the JVM. Use the following command to reproduce the flaky behavior:

`mvn edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.json.junit.XMLTest#testIndentComplicatedJsonObjectWithArrayAndWithConfig`

The test will fail intermittently depending on the runtime ordering of keys in the nested JSON object.


### ▸ Expected Results
The test should pass consistently across different JVMs and environments, including when run with NonDex.


### ▸ Actual Results
When key order differs in the JSON-to-XML output, the test fails with .similar() returning false, even though the underlying data is structurally equivalent.


### ▸ Description of Fix
Created helper method deepSort(Object input) into `XMLTest.java` . It recursively traverses any `JSONObject` or `JSONArray` and returns a new data structure with all JSON objects' keys sorted using `TreeMap`. This ensures deterministic ordering before serialization with  `XML.toString()`. This change guarantees stable test results.